### PR TITLE
feat: add /area endpoint for GPS-based alert area lookup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.12-alpine
 
 RUN rm -rf /var/cache/apk/*
 
+RUN apk add --no-cache geos
+
 #install python dependencies from requirements.txt
 COPY requirements.txt /opt/redalert/
 RUN pip install -r /opt/redalert/requirements.txt --no-cache-dir

--- a/redalert.py
+++ b/redalert.py
@@ -8,8 +8,10 @@ import json
 import logging
 import aiomqtt
 import time
+import pathlib
 from dataclasses import dataclass, asdict
 from typing import List, Optional
+from shapely.geometry import Point, Polygon
 
 @dataclass
 class AlertObject:
@@ -63,6 +65,18 @@ DEBUG_ALERT_DATA = {
 alerts = {}
 ALERT_TTL = 3600  # 1 hour in seconds
 last_heartbeat: float = 0.0
+
+# Area endpoint configuration
+AREA_POLYGONS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "area_polygons.json")
+AREA_REFRESH_INTERVAL = 86400  # 24 hours in seconds
+AREA_FETCH_CONCURRENCY = 20
+OREF_CITIES_URL = "https://alerts-history.oref.org.il/Shared/Ajax/GetCitiesMix.aspx"
+MESER_SEGMENTS_URL = "https://dist-android.meser-hadash.org.il/smart-dist/services/anonymous/segments/android?instance=1544803905&locale=iw_IL"
+MESER_POLYGON_URL_TEMPLATE = "https://services.meser-hadash.org.il/smart-dist/services/anonymous/polygon/id/android?instance=1544803905&id={segment_id}"
+
+# In-memory bounding box index: {"city_name": {"migun_time": int, "bbox": (min_lat, max_lat, min_lon, max_lon)}}
+area_bbox_index: dict = {}
+area_data_loaded: bool = False
 
 
 def is_test_alert(alert: AlertObject) -> bool:
@@ -124,6 +138,229 @@ def cleanup_alerts():
     for aid in to_remove:
         del alerts[aid]
 
+
+def _area_file_is_fresh() -> bool:
+    p = pathlib.Path(AREA_POLYGONS_FILE)
+    if not p.exists():
+        return False
+    age = time.time() - p.stat().st_mtime
+    return age < AREA_REFRESH_INTERVAL
+
+
+async def fetch_area_polygons(session: aiohttp.ClientSession) -> dict:
+    logger.info("Starting area polygon data fetch...")
+    try:
+        # Step 1: Fetch city list from Pikud Haoref
+        async with await session.get(OREF_CITIES_URL) as resp:
+            if resp.status != 200:
+                logger.error(f"Failed to fetch cities: HTTP {resp.status}")
+                return {}
+            cities_data = await resp.json(content_type=None)
+
+        city_map = {}
+        for city in cities_data:
+            label = city.get("label", "").strip()
+            migun_time = city.get("migun_time", "0")
+            if label:
+                city_map[label] = int(migun_time) if str(migun_time).isdigit() else 0
+
+        logger.info(f"Fetched {len(city_map)} cities from Oref")
+
+        # Step 2: Fetch segments from meser-hadash
+        async with await session.get(MESER_SEGMENTS_URL) as resp:
+            if resp.status != 200:
+                logger.error(f"Failed to fetch segments: HTTP {resp.status}")
+                return {}
+            segments_data = await resp.json(content_type=None)
+
+        segments = segments_data.get("segments", {})
+        # Build name -> segment_id mapping
+        segment_by_name = {}
+        for seg_id, seg in segments.items():
+            name = seg.get("name", "").strip()
+            if name:
+                segment_by_name[name] = seg.get("id", seg_id)
+
+        # Step 3: Match cities to segments and fetch polygons
+        matched = []
+        for city_name, migun_time in city_map.items():
+            if city_name in segment_by_name:
+                matched.append((city_name, migun_time, segment_by_name[city_name]))
+
+        logger.info(f"Matched {len(matched)} cities to segments")
+
+        result = {}
+        sem = asyncio.Semaphore(AREA_FETCH_CONCURRENCY)
+
+        async def fetch_polygon(city_name, migun_time, segment_id):
+            async with sem:
+                try:
+                    poly_url = MESER_POLYGON_URL_TEMPLATE.format(segment_id=segment_id)
+                    async with await session.get(poly_url) as resp:
+                        if resp.status != 200:
+                            return
+                        poly_data = await resp.json(content_type=None)
+                    point_list = poly_data.get("polygonPointList", [])
+                    if point_list and len(point_list) > 0:
+                        polygon = point_list[0] if isinstance(point_list[0][0], list) else point_list
+                        result[city_name] = {"migun_time": migun_time, "polygon": polygon}
+                except Exception as e:
+                    logger.warning(f"Failed to fetch polygon for {city_name}: {e}")
+
+        tasks = [fetch_polygon(cn, mt, sid) for cn, mt, sid in matched]
+        await asyncio.gather(*tasks)
+
+        logger.info(f"Area polygon fetch complete. Total areas: {len(result)}")
+        return result
+    except Exception as e:
+        logger.error(f"Error fetching area polygons: {e}")
+        return {}
+
+
+def build_bbox_index(area_data: dict) -> dict:
+    index = {}
+    for name, data in area_data.items():
+        polygon = data.get("polygon", [])
+        if not polygon:
+            continue
+        lats = [p[0] for p in polygon]
+        lons = [p[1] for p in polygon]
+        index[name] = {
+            "migun_time": data.get("migun_time", 0),
+            "bbox": (min(lats), max(lats), min(lons), max(lons))
+        }
+    return index
+
+
+async def load_area_data():
+    global area_bbox_index, area_data_loaded
+
+    if _area_file_is_fresh():
+        logger.info("Loading area data from fresh file...")
+        try:
+            with open(AREA_POLYGONS_FILE, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            area_bbox_index = build_bbox_index(data)
+            area_data_loaded = True
+            logger.info(f"Loaded {len(area_bbox_index)} areas from file")
+            return
+        except Exception as e:
+            logger.error(f"Failed to load area file: {e}")
+
+    # File missing or stale — fetch fresh data
+    logger.info("Fetching fresh area data...")
+    timeout = aiohttp.ClientTimeout(sock_connect=10, sock_read=30)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            data = await fetch_area_polygons(session)
+    except Exception as e:
+        logger.error(f"Failed to create session for area fetch: {e}")
+        data = {}
+
+    if data:
+        try:
+            with open(AREA_POLYGONS_FILE, 'w', encoding='utf-8') as f:
+                json.dump(data, f, ensure_ascii=False)
+            area_bbox_index = build_bbox_index(data)
+            area_data_loaded = True
+            logger.info(f"Saved and indexed {len(area_bbox_index)} areas")
+            return
+        except Exception as e:
+            logger.error(f"Failed to save area file: {e}")
+
+    # Fetch failed — try stale file as fallback
+    if pathlib.Path(AREA_POLYGONS_FILE).exists():
+        logger.warning("Fetch failed, falling back to stale area file")
+        try:
+            with open(AREA_POLYGONS_FILE, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            area_bbox_index = build_bbox_index(data)
+            area_data_loaded = True
+            logger.info(f"Loaded {len(area_bbox_index)} areas from stale file")
+            return
+        except Exception as e:
+            logger.error(f"Failed to load stale area file: {e}")
+
+    logger.error("No area data available")
+    area_data_loaded = False
+
+
+async def area_refresh_loop():
+    while True:
+        try:
+            await asyncio.sleep(AREA_REFRESH_INTERVAL)
+            await load_area_data()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"Error in area refresh loop: {e}")
+
+
+def lookup_area(lat: float, lon: float) -> Optional[dict]:
+    # Pre-filter candidates using bounding box
+    candidates = []
+    for name, info in area_bbox_index.items():
+        min_lat, max_lat, min_lon, max_lon = info["bbox"]
+        if min_lat <= lat <= max_lat and min_lon <= lon <= max_lon:
+            candidates.append((name, info["migun_time"]))
+
+    if not candidates:
+        return None
+
+    # Load polygons from file and check containment
+    try:
+        with open(AREA_POLYGONS_FILE, 'r', encoding='utf-8') as f:
+            all_data = json.load(f)
+    except Exception:
+        return None
+
+    point = Point(lon, lat)
+    for name, migun_time in candidates:
+        area_entry = all_data.get(name)
+        if not area_entry:
+            continue
+        poly_coords = area_entry.get("polygon", [])
+        if len(poly_coords) < 3:
+            continue
+        # File stores [lat, lon], shapely needs (x=lon, y=lat)
+        shapely_coords = [(p[1], p[0]) for p in poly_coords]
+        polygon = Polygon(shapely_coords)
+        if polygon.contains(point):
+            return {"area": name, "migun_time": migun_time}
+
+    return None
+
+
+async def area_handler(request):
+    lat_str = request.query.get("lat")
+    lon_str = request.query.get("lon")
+
+    if not lat_str or not lon_str:
+        return aiohttp.web.json_response(
+            {"error": "Missing or invalid lat/lon query parameters"}, status=400
+        )
+    try:
+        lat = float(lat_str)
+        lon = float(lon_str)
+    except ValueError:
+        return aiohttp.web.json_response(
+            {"error": "Missing or invalid lat/lon query parameters"}, status=400
+        )
+
+    if not area_data_loaded:
+        return aiohttp.web.json_response(
+            {"error": "Area data not loaded yet"}, status=503
+        )
+
+    result = lookup_area(lat, lon)
+    if result:
+        return aiohttp.web.json_response(result, status=200)
+
+    return aiohttp.web.json_response(
+        {"error": "No alert area found for given coordinates"}, status=404
+    )
+
+
 async def health_handler(request):
     age = time.time() - last_heartbeat
     if last_heartbeat == 0 or age > HEALTH_THRESHOLD:
@@ -138,6 +375,7 @@ async def health_handler(request):
 async def run_health_server():
     app = aiohttp.web.Application()
     app.router.add_get("/health", health_handler)
+    app.router.add_get("/area", area_handler)
     runner = aiohttp.web.AppRunner(app, access_log=None)
     await runner.setup()
     site = aiohttp.web.TCPSite(runner, "0.0.0.0", HEALTH_PORT)
@@ -184,5 +422,6 @@ async def monitor():
 
 if __name__ == '__main__':
     async def main():
-        await asyncio.gather(monitor(), run_health_server())
+        await load_area_data()
+        await asyncio.gather(monitor(), run_health_server(), area_refresh_loop())
     asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp==3.13.3
 aiomqtt==2.4.0
+shapely==2.0.7

--- a/tests/test_redalert.py
+++ b/tests/test_redalert.py
@@ -705,3 +705,486 @@ def test_main_block(monkeypatch):
         # Simulate __main__
         if hasattr(ra, '__name__'):
             assert True
+
+
+# ====== Area endpoint tests ======
+
+
+def test_area_file_is_fresh_no_file(monkeypatch):
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', '/tmp/nonexistent_area_test.json')
+    assert redalert._area_file_is_fresh() is False
+
+
+def test_area_file_is_fresh_stale(monkeypatch, tmp_path):
+    f = tmp_path / "area_polygons.json"
+    f.write_text("{}")
+    # Set mtime to 25 hours ago
+    old_time = time.time() - 90000
+    os.utime(str(f), (old_time, old_time))
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', str(f))
+    assert redalert._area_file_is_fresh() is False
+
+
+def test_area_file_is_fresh_recent(monkeypatch, tmp_path):
+    f = tmp_path / "area_polygons.json"
+    f.write_text("{}")
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', str(f))
+    assert redalert._area_file_is_fresh() is True
+
+
+def test_build_bbox_index():
+    data = {
+        "תל אביב": {
+            "migun_time": 90,
+            "polygon": [[32.0, 34.7], [32.1, 34.7], [32.1, 34.8], [32.0, 34.8]]
+        }
+    }
+    idx = redalert.build_bbox_index(data)
+    assert "תל אביב" in idx
+    assert idx["תל אביב"]["migun_time"] == 90
+    bbox = idx["תל אביב"]["bbox"]
+    assert bbox == (32.0, 32.1, 34.7, 34.8)
+
+
+def test_build_bbox_index_empty():
+    assert redalert.build_bbox_index({}) == {}
+
+
+def test_build_bbox_index_skips_empty_polygon():
+    data = {"city": {"migun_time": 0, "polygon": []}}
+    assert redalert.build_bbox_index(data) == {}
+
+
+def test_lookup_area_hit(monkeypatch, tmp_path):
+    # Square polygon around (32.05, 34.75)
+    area_data = {
+        "תל אביב": {
+            "migun_time": 90,
+            "polygon": [[32.0, 34.7], [32.1, 34.7], [32.1, 34.8], [32.0, 34.8]]
+        }
+    }
+    f = tmp_path / "area_polygons.json"
+    f.write_text(json.dumps(area_data, ensure_ascii=False))
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', str(f))
+    monkeypatch.setattr(redalert, 'area_bbox_index', redalert.build_bbox_index(area_data))
+
+    result = redalert.lookup_area(32.05, 34.75)
+    assert result is not None
+    assert result["area"] == "תל אביב"
+    assert result["migun_time"] == 90
+
+
+def test_lookup_area_miss(monkeypatch, tmp_path):
+    area_data = {
+        "תל אביב": {
+            "migun_time": 90,
+            "polygon": [[32.0, 34.7], [32.1, 34.7], [32.1, 34.8], [32.0, 34.8]]
+        }
+    }
+    f = tmp_path / "area_polygons.json"
+    f.write_text(json.dumps(area_data, ensure_ascii=False))
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', str(f))
+    monkeypatch.setattr(redalert, 'area_bbox_index', redalert.build_bbox_index(area_data))
+
+    result = redalert.lookup_area(33.0, 35.0)
+    assert result is None
+
+
+def test_lookup_area_bbox_hit_polygon_miss(monkeypatch, tmp_path):
+    # Triangle polygon — point in bbox corner but outside triangle
+    area_data = {
+        "triangle": {
+            "migun_time": 60,
+            "polygon": [[32.0, 34.7], [32.1, 34.8], [32.0, 34.8]]
+        }
+    }
+    f = tmp_path / "area_polygons.json"
+    f.write_text(json.dumps(area_data, ensure_ascii=False))
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', str(f))
+    monkeypatch.setattr(redalert, 'area_bbox_index', redalert.build_bbox_index(area_data))
+
+    # Point at (32.09, 34.71) is inside bbox but outside the triangle
+    result = redalert.lookup_area(32.09, 34.71)
+    assert result is None
+
+
+def test_lookup_area_no_candidates(monkeypatch):
+    monkeypatch.setattr(redalert, 'area_bbox_index', {})
+    result = redalert.lookup_area(32.05, 34.75)
+    assert result is None
+
+
+def test_lookup_area_file_read_error(monkeypatch):
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', '/tmp/nonexistent.json')
+    monkeypatch.setattr(redalert, 'area_bbox_index', {
+        "city": {"migun_time": 0, "bbox": (30.0, 35.0, 34.0, 36.0)}
+    })
+    result = redalert.lookup_area(32.0, 35.0)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_area_handler_success(monkeypatch):
+    monkeypatch.setattr(redalert, 'area_data_loaded', True)
+    monkeypatch.setattr(redalert, 'lookup_area', lambda lat, lon: {"area": "תל אביב", "migun_time": 90})
+    request = MagicMock()
+    request.query = {"lat": "32.0853", "lon": "34.7818"}
+    response = await redalert.area_handler(request)
+    assert response.status == 200
+    body = json.loads(response.body)
+    assert body["area"] == "תל אביב"
+    assert body["migun_time"] == 90
+
+
+@pytest.mark.asyncio
+async def test_area_handler_not_found(monkeypatch):
+    monkeypatch.setattr(redalert, 'area_data_loaded', True)
+    monkeypatch.setattr(redalert, 'lookup_area', lambda lat, lon: None)
+    request = MagicMock()
+    request.query = {"lat": "32.0853", "lon": "34.7818"}
+    response = await redalert.area_handler(request)
+    assert response.status == 404
+    body = json.loads(response.body)
+    assert "No alert area found" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_area_handler_not_loaded(monkeypatch):
+    monkeypatch.setattr(redalert, 'area_data_loaded', False)
+    request = MagicMock()
+    request.query = {"lat": "32.0853", "lon": "34.7818"}
+    response = await redalert.area_handler(request)
+    assert response.status == 503
+    body = json.loads(response.body)
+    assert "not loaded" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_area_handler_missing_params():
+    request = MagicMock()
+    request.query = {}
+    response = await redalert.area_handler(request)
+    assert response.status == 400
+
+
+@pytest.mark.asyncio
+async def test_area_handler_invalid_params():
+    request = MagicMock()
+    request.query = {"lat": "abc", "lon": "xyz"}
+    response = await redalert.area_handler(request)
+    assert response.status == 400
+
+
+class AsyncJsonContextResponse:
+    def __init__(self, status, json_value):
+        self.status = status
+        self._json_value = json_value
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def json(self, *args, **kwargs):
+        return self._json_value
+
+
+@pytest.mark.asyncio
+async def test_fetch_area_polygons_success():
+    cities = [
+        {"label": "תל אביב", "migun_time": "90"},
+        {"label": "חיפה", "migun_time": "60"}
+    ]
+    segments = {
+        "segments": {
+            "1": {"id": 1, "name": "תל אביב", "centerX": 34.78, "centerY": 32.08},
+            "2": {"id": 2, "name": "חיפה", "centerX": 34.99, "centerY": 32.82}
+        }
+    }
+    polygon_ta = {"polygonPointList": [[[32.0, 34.7], [32.1, 34.7], [32.1, 34.8], [32.0, 34.8]]]}
+    polygon_haifa = {"polygonPointList": [[[32.8, 34.9], [32.9, 34.9], [32.9, 35.0], [32.8, 35.0]]]}
+
+    call_count = 0
+    async def mock_get(url, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if "GetCitiesMix" in url:
+            return AsyncJsonContextResponse(200, cities)
+        elif "segments" in url:
+            return AsyncJsonContextResponse(200, segments)
+        elif "id=1" in url:
+            return AsyncJsonContextResponse(200, polygon_ta)
+        elif "id=2" in url:
+            return AsyncJsonContextResponse(200, polygon_haifa)
+        return AsyncJsonContextResponse(404, {})
+
+    session = AsyncMock()
+    session.get = mock_get
+
+    result = await redalert.fetch_area_polygons(session)
+    assert "תל אביב" in result
+    assert "חיפה" in result
+    assert result["תל אביב"]["migun_time"] == 90
+    assert len(result["תל אביב"]["polygon"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_fetch_area_polygons_cities_failure():
+    async def mock_get(url, **kwargs):
+        return AsyncJsonContextResponse(500, None)
+
+    session = AsyncMock()
+    session.get = mock_get
+    result = await redalert.fetch_area_polygons(session)
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_area_polygons_segments_failure():
+    cities = [{"label": "תל אביב", "migun_time": "90"}]
+    call_count = 0
+    async def mock_get(url, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if "GetCitiesMix" in url:
+            return AsyncJsonContextResponse(200, cities)
+        return AsyncJsonContextResponse(500, None)
+
+    session = AsyncMock()
+    session.get = mock_get
+    result = await redalert.fetch_area_polygons(session)
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_area_polygons_exception():
+    session = AsyncMock()
+    async def raise_error(*args, **kwargs):
+        raise ConnectionError("Network error")
+    session.get = raise_error
+    result = await redalert.fetch_area_polygons(session)
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_load_area_data_from_fresh_file(monkeypatch, tmp_path):
+    area_data = {
+        "תל אביב": {
+            "migun_time": 90,
+            "polygon": [[32.0, 34.7], [32.1, 34.7], [32.1, 34.8], [32.0, 34.8]]
+        }
+    }
+    f = tmp_path / "area_polygons.json"
+    f.write_text(json.dumps(area_data, ensure_ascii=False))
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', str(f))
+    monkeypatch.setattr(redalert, 'area_data_loaded', False)
+    monkeypatch.setattr(redalert, 'area_bbox_index', {})
+
+    await redalert.load_area_data()
+    assert redalert.area_data_loaded is True
+    assert "תל אביב" in redalert.area_bbox_index
+
+
+@pytest.mark.asyncio
+async def test_load_area_data_fetch_and_save(monkeypatch, tmp_path):
+    f = tmp_path / "area_polygons.json"
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', str(f))
+    monkeypatch.setattr(redalert, 'area_data_loaded', False)
+    monkeypatch.setattr(redalert, 'area_bbox_index', {})
+
+    test_data = {
+        "חיפה": {
+            "migun_time": 60,
+            "polygon": [[32.8, 34.9], [32.9, 34.9], [32.9, 35.0], [32.8, 35.0]]
+        }
+    }
+
+    async def mock_fetch(session):
+        return test_data
+    monkeypatch.setattr(redalert, 'fetch_area_polygons', mock_fetch)
+
+    await redalert.load_area_data()
+    assert redalert.area_data_loaded is True
+    assert "חיפה" in redalert.area_bbox_index
+    assert f.exists()
+
+
+@pytest.mark.asyncio
+async def test_load_area_data_fetch_fails_stale_file(monkeypatch, tmp_path):
+    area_data = {
+        "old_city": {
+            "migun_time": 30,
+            "polygon": [[31.0, 34.0], [31.1, 34.0], [31.1, 34.1], [31.0, 34.1]]
+        }
+    }
+    f = tmp_path / "area_polygons.json"
+    f.write_text(json.dumps(area_data, ensure_ascii=False))
+    # Make file stale
+    old_time = time.time() - 90000
+    os.utime(str(f), (old_time, old_time))
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', str(f))
+    monkeypatch.setattr(redalert, 'area_data_loaded', False)
+    monkeypatch.setattr(redalert, 'area_bbox_index', {})
+
+    async def mock_fetch(session):
+        return {}
+    monkeypatch.setattr(redalert, 'fetch_area_polygons', mock_fetch)
+
+    await redalert.load_area_data()
+    assert redalert.area_data_loaded is True
+    assert "old_city" in redalert.area_bbox_index
+
+
+@pytest.mark.asyncio
+async def test_load_area_data_fetch_fails_no_file(monkeypatch, tmp_path):
+    f = tmp_path / "nonexistent_area.json"
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', str(f))
+    monkeypatch.setattr(redalert, 'area_data_loaded', False)
+    monkeypatch.setattr(redalert, 'area_bbox_index', {})
+
+    async def mock_fetch(session):
+        return {}
+    monkeypatch.setattr(redalert, 'fetch_area_polygons', mock_fetch)
+
+    await redalert.load_area_data()
+    assert redalert.area_data_loaded is False
+
+
+@pytest.mark.asyncio
+async def test_area_refresh_loop(monkeypatch):
+    call_count = 0
+    async def mock_load():
+        nonlocal call_count
+        call_count += 1
+
+    monkeypatch.setattr(redalert, 'load_area_data', mock_load)
+
+    sleep_count = 0
+    async def fake_sleep(*args, **kwargs):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count >= 2:
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(asyncio, 'sleep', fake_sleep)
+
+    try:
+        await redalert.area_refresh_loop()
+    except asyncio.CancelledError:
+        pass
+
+    assert call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_area_refresh_loop_handles_exception(monkeypatch):
+    call_count = 0
+    async def mock_load():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("transient error")
+
+    monkeypatch.setattr(redalert, 'load_area_data', mock_load)
+
+    sleep_count = 0
+    async def fake_sleep(*args, **kwargs):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count >= 3:
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(asyncio, 'sleep', fake_sleep)
+
+    try:
+        await redalert.area_refresh_loop()
+    except asyncio.CancelledError:
+        pass
+
+    assert call_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_run_health_server_registers_area_route(monkeypatch):
+    mock_app = MagicMock()
+    mock_runner = AsyncMock()
+    mock_site = AsyncMock()
+
+    monkeypatch.setattr(redalert.aiohttp.web, 'Application', lambda: mock_app)
+    monkeypatch.setattr(redalert.aiohttp.web, 'AppRunner', lambda *a, **kw: mock_runner)
+    monkeypatch.setattr(redalert.aiohttp.web, 'TCPSite', lambda runner, host, port: mock_site)
+
+    async def fake_sleep(*args, **kwargs):
+        raise asyncio.CancelledError()
+    monkeypatch.setattr(asyncio, 'sleep', fake_sleep)
+
+    try:
+        await redalert.run_health_server()
+    except asyncio.CancelledError:
+        pass
+
+    # Verify both /health and /area routes were registered
+    add_get_calls = mock_app.router.add_get.call_args_list
+    routes = [call[0][0] for call in add_get_calls]
+    assert "/health" in routes
+    assert "/area" in routes
+
+
+@pytest.mark.asyncio
+async def test_fetch_area_polygons_polygon_fetch_failure():
+    """Test that individual polygon fetch failures are handled gracefully."""
+    cities = [{"label": "תל אביב", "migun_time": "90"}]
+    segments = {
+        "segments": {
+            "1": {"id": 1, "name": "תל אביב", "centerX": 34.78, "centerY": 32.08}
+        }
+    }
+
+    async def mock_get(url, **kwargs):
+        if "GetCitiesMix" in url:
+            return AsyncJsonContextResponse(200, cities)
+        elif "segments" in url:
+            return AsyncJsonContextResponse(200, segments)
+        # Polygon fetch fails
+        return AsyncJsonContextResponse(500, None)
+
+    session = AsyncMock()
+    session.get = mock_get
+    result = await redalert.fetch_area_polygons(session)
+    # City not in result because polygon fetch failed
+    assert "תל אביב" not in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_area_polygons_no_matches():
+    """Test when no cities match any segments."""
+    cities = [{"label": "nonexistent_city", "migun_time": "90"}]
+    segments = {
+        "segments": {
+            "1": {"id": 1, "name": "other_city", "centerX": 34.78, "centerY": 32.08}
+        }
+    }
+
+    async def mock_get(url, **kwargs):
+        if "GetCitiesMix" in url:
+            return AsyncJsonContextResponse(200, cities)
+        elif "segments" in url:
+            return AsyncJsonContextResponse(200, segments)
+        return AsyncJsonContextResponse(404, {})
+
+    session = AsyncMock()
+    session.get = mock_get
+    result = await redalert.fetch_area_polygons(session)
+    assert result == {}
+
+
+def test_lookup_area_polygon_too_few_points(monkeypatch, tmp_path):
+    """Test polygon with fewer than 3 points is skipped."""
+    area_data = {
+        "tiny": {"migun_time": 10, "polygon": [[32.0, 34.7], [32.1, 34.8]]}
+    }
+    f = tmp_path / "area_polygons.json"
+    f.write_text(json.dumps(area_data, ensure_ascii=False))
+    monkeypatch.setattr(redalert, 'AREA_POLYGONS_FILE', str(f))
+    monkeypatch.setattr(redalert, 'area_bbox_index', redalert.build_bbox_index(area_data))
+
+    result = redalert.lookup_area(32.05, 34.75)
+    assert result is None


### PR DESCRIPTION
## Summary
- Add new `GET /area?lat=...&lon=...` endpoint that returns the matching Oref alert area and shelter time (migun_time) for given GPS coordinates — designed for Home Assistant real-time location queries
- Data pipeline fetches city list from Pikud Haoref, cross-references with meser-hadash polygon boundaries, and caches results to `area_polygons.json`
- In-memory bounding box index for fast pre-filtering, with shapely point-in-polygon for precise containment checks
- Auto-refresh every 24 hours with graceful fallback to stale data on fetch failures

## Test plan
- [x] 30 new tests added (63 total), all passing
- [x] 96% code coverage on redalert.py
- [ ] Verify `/area` endpoint returns correct area for known Tel Aviv coordinates
- [ ] Verify 404 response for coordinates outside any known area
- [ ] Verify 503 response when area data hasn't loaded yet
- [ ] Verify Docker build succeeds with new `geos` dependency

https://claude.ai/code/session_01Eq92qr4qGuk8JVds6i43Bg